### PR TITLE
#29 - Only build jar with main-class if needed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,10 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+
+				<configuration>
+					<layout>NONE</layout>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/rest/multi-store/pom.xml
+++ b/rest/multi-store/pom.xml
@@ -32,5 +32,18 @@
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
 	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>example.Application</mainClass>
+					<layout>JAR</layout>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/rest/projections/pom.xml
+++ b/rest/projections/pom.xml
@@ -25,5 +25,18 @@
 		</dependency>
 
 	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>example.orders.Application</mainClass>
+					<layout>JAR</layout>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/rest/security/pom.xml
+++ b/rest/security/pom.xml
@@ -42,5 +42,18 @@
 			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<mainClass>example.company.Application</mainClass>
+					<layout>JAR</layout>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/rest/starbucks/pom.xml
+++ b/rest/starbucks/pom.xml
@@ -39,6 +39,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<mainClass>example.stores.StoreApp</mainClass>
+					<layout>JAR</layout>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Explicitly configured layout to NONE in parent pom.xml to skip generation of jars and lookup for main-classes for projects that don't need them.
Add generation of jars and main-class configuration to the projects that require this (multi-store, projections, (rest)security and starbucks).
