### PR TITLE
#66 - Added JPA example for using Java Streams with a derived query.

### DIFF
--- a/jpa/java8/src/main/java/example/springdata/jpa/java8/CustomerRepository.java
+++ b/jpa/java8/src/main/java/example/springdata/jpa/java8/CustomerRepository.java
@@ -18,6 +18,8 @@ package example.springdata.jpa.java8;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import javax.persistence.criteria.CriteriaQuery;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
@@ -26,6 +28,7 @@ import org.springframework.data.repository.Repository;
  * Repository to manage {@link Customer} instances.
  * 
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public interface CustomerRepository extends Repository<Customer, Long> {
 
@@ -64,11 +67,23 @@ public interface CustomerRepository extends Repository<Customer, Long> {
 	}
 
 	/**
-	 * Sample method to demonstrate support for {@link Stream} as a return type. The query is executed in a streaming
-	 * fashion which means that the method returns as soon as the first results are ready.
+	 * Sample method to demonstrate support for {@link Stream} as a return type with a custom query. The query is executed
+	 * in a streaming fashion which means that the method returns as soon as the first results are ready.
 	 * 
 	 * @return
 	 */
 	@Query("select c from Customer c")
 	Stream<Customer> streamAllCustomers();
+
+	/**
+	 * Sample method to demonstrate support for {@link Stream} as a return type with a derived query. The query is
+	 * executed in a streaming fashion which means that the method returns as soon as the first results are ready.
+	 * <p>
+	 * Note that we cannot just name the method {@link CrudRepository#findAll()} since this wouldn't allow us to perform
+	 * real streaming since the query is executed directly in SimpleJpaRepository. {@code findAllBy} however creates a
+	 * {@link CriteriaQuery} that we can transform to a streaming query.
+	 * 
+	 * @return
+	 */
+	Stream<Customer> findAllBy();
 }

--- a/jpa/java8/src/main/java/example/springdata/jpa/java8/CustomerRepository.java
+++ b/jpa/java8/src/main/java/example/springdata/jpa/java8/CustomerRepository.java
@@ -18,8 +18,6 @@ package example.springdata.jpa.java8;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.persistence.criteria.CriteriaQuery;
-
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
@@ -78,12 +76,8 @@ public interface CustomerRepository extends Repository<Customer, Long> {
 	/**
 	 * Sample method to demonstrate support for {@link Stream} as a return type with a derived query. The query is
 	 * executed in a streaming fashion which means that the method returns as soon as the first results are ready.
-	 * <p>
-	 * Note that we cannot just name the method {@link CrudRepository#findAll()} since this wouldn't allow us to perform
-	 * real streaming since the query is executed directly in SimpleJpaRepository. {@code findAllBy} however creates a
-	 * {@link CriteriaQuery} that we can transform to a streaming query.
 	 * 
 	 * @return
 	 */
-	Stream<Customer> findAllBy();
+	Stream<Customer> findAllByLastnameIsNotNull();
 }

--- a/jpa/java8/src/test/java/example/springdata/jpa/java8/Java8IntegrationTests.java
+++ b/jpa/java8/src/test/java/example/springdata/jpa/java8/Java8IntegrationTests.java
@@ -73,16 +73,34 @@ public class Java8IntegrationTests {
 	}
 
 	/**
-	 * Streaming data from the store by using a repsoitory method that returns a {@link Stream}. Note, that since the
+	 * Streaming data from the store by using a repository method that returns a {@link Stream}. Note, that since the
 	 * resulting {@link Stream} contains state it needs to be closed explicitly after use!
 	 */
 	@Test
-	public void useJava8StreamsDirectly() {
+	public void useJava8StreamsDirectlyWithCustomQuery() {
 
 		Customer customer1 = repository.save(new Customer("Customer1", "Foo"));
 		Customer customer2 = repository.save(new Customer("Customer2", "Bar"));
 
 		try (Stream<Customer> stream = repository.streamAllCustomers()) {
+
+			List<Customer> customers = stream.collect(Collectors.toList());
+
+			assertThat(customers, IsCollectionContaining.<Customer> hasItems(customer1, customer2));
+		}
+	}
+
+	/**
+	 * Streaming data from the store by using a repository method that returns a {@link Stream} with a derived query.
+	 * Note, that since the resulting {@link Stream} contains state it needs to be closed explicitly after use!
+	 */
+	@Test
+	public void useJava8StreamsDirectlyWithDerivedQuery() {
+
+		Customer customer1 = repository.save(new Customer("Customer1", "Foo"));
+		Customer customer2 = repository.save(new Customer("Customer2", "Bar"));
+
+		try (Stream<Customer> stream = repository.findAllBy()) {
 
 			List<Customer> customers = stream.collect(Collectors.toList());
 

--- a/jpa/java8/src/test/java/example/springdata/jpa/java8/Java8IntegrationTests.java
+++ b/jpa/java8/src/test/java/example/springdata/jpa/java8/Java8IntegrationTests.java
@@ -100,7 +100,7 @@ public class Java8IntegrationTests {
 		Customer customer1 = repository.save(new Customer("Customer1", "Foo"));
 		Customer customer2 = repository.save(new Customer("Customer2", "Bar"));
 
-		try (Stream<Customer> stream = repository.findAllBy()) {
+		try (Stream<Customer> stream = repository.findAllByLastnameIsNotNull()) {
 
 			List<Customer> customers = stream.collect(Collectors.toList());
 


### PR DESCRIPTION
This example demonstrates that it is necessary to use a derived query method in combination with Stream since the default findAll() variants don’t support to return a stream.