### PR TITLE
Add instruction to create mongodb data directory

### DIFF
--- a/rest/starbucks/README.md
+++ b/rest/starbucks/README.md
@@ -4,7 +4,7 @@ This sample app exposes 10843 Starbucks coffee shops via a RESTful API that allo
 
 ## Quickstart
 
-1. Install MongoDB (http://www.mongodb.org/downloads, unzip, run `bin/mongod --dbpath=data`)
+1. Install MongoDB (http://www.mongodb.org/downloads, unzip, run `mkdir data`, run `bin/mongod --dbpath=data`)
 2. Build and run the app (`mvn spring-boot:run`)
 3. Access the root resource (`curl http://localhost:8080`) and traverse hyperlinks.
 4. Or access the location search directly (e.g. `http://localhost:8080/stores/search/findByAddressLocationNear?location=40.740337,-73.995146&distance=0.5miles`)


### PR DESCRIPTION
Running mongodb fails if the `--dbpath` directory does not yet exist.
This change instructs the user to create the directory first.