### PR TITLE
#107 - Added example for Spring Security Integration for MongoDB

### DIFF
--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -21,6 +21,7 @@
 		<module>example</module>
 		<module>text-search</module>
 		<module>java8</module>
+		<module>security</module>
 		<module>util</module>
 		<module>geo-json</module>
 	</modules>

--- a/mongodb/security/README.md
+++ b/mongodb/security/README.md
@@ -1,0 +1,18 @@
+# Spring Data MongoDB - Spring Security integration.
+
+This project contains samples of the Spring Security integration in Spring Data (MongoDB).
+
+## Support for SpEL Expression based filtering
+
+```java
+public interface PersonRepository extends CrudRepository<Person, String> {
+
+  @Override
+  List<Person> findAll();
+
+  //Custom Query method with filtering based on Spring Security context information
+  @Query("{id: ?#{ hasRole('ROLE_ADMIN') ? {$exists:true} : principal.id}}")
+  List<Person> findAllForCurrentUserById();
+}
+```
+

--- a/mongodb/security/pom.xml
+++ b/mongodb/security/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.data.examples</groupId>
+		<artifactId>spring-data-mongodb-examples</artifactId>
+		<version>1.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-data-mongodb-security</artifactId>
+	<name>Spring Data MongoDB - Spring Security Integration</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-data-mongodb-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-mongodb</artifactId>
+			<version>1.8.0.DATAMONGO-1244-SNAPSHOT</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-data</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/mongodb/security/src/main/java/example/springdata/mongodb/people/ApplicationConfiguration.java
+++ b/mongodb/security/src/main/java/example/springdata/mongodb/people/ApplicationConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.mongodb.core.mapping.event.LoggingEventListener;
+import org.springframework.data.repository.query.spi.EvaluationContextExtension;
+import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
+
+/**
+ * Simple configuration that registers a {@link LoggingEventListener} to demonstrate mapping behaviour when Java 8
+ * Streams are used.
+ * 
+ * @author Thomas Darimont
+ */
+@SpringBootApplication
+class ApplicationConfiguration {
+
+	public @Bean LoggingEventListener mongoEventListener() {
+		return new LoggingEventListener();
+	}
+ 
+	@Bean
+	public EvaluationContextExtension securityExtension() {
+		return new SecurityEvaluationContextExtension();
+	}
+}

--- a/mongodb/security/src/main/java/example/springdata/mongodb/people/Person.java
+++ b/mongodb/security/src/main/java/example/springdata/mongodb/people/Person.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.annotation.Id;
+
+/**
+ * An entity to represent a Person.
+ * 
+ * @author Thomas Darimont
+ */
+@Data
+@RequiredArgsConstructor
+public class Person {
+
+	private @Id String id;
+	private final String firstname;
+	private final String lastname;
+}

--- a/mongodb/security/src/main/java/example/springdata/mongodb/people/PersonRepository.java
+++ b/mongodb/security/src/main/java/example/springdata/mongodb/people/PersonRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Repository interface to manage {@link Person} instances.
+ * 
+ * @author Thomas Darimont
+ */
+public interface PersonRepository extends CrudRepository<Person, String> {
+
+	List<Person> findAll();
+
+	@Query("{id: ?#{ hasRole('ROLE_ADMIN') ? {$exists:true} : principal.id}}")
+	List<Person> findAllForCurrentUserById();
+}

--- a/mongodb/security/src/test/java/example/springdata/mongodb/people/PersonRepositoryIntegrationTest.java
+++ b/mongodb/security/src/test/java/example/springdata/mongodb/people/PersonRepositoryIntegrationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import example.springdata.mongodb.util.RequiresMongoDB;
+
+/**
+ * Integration test for {@link PersonRepository}.
+ * 
+ * @author Thomas Darimont
+ * @authot Oliver Gierke
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = ApplicationConfiguration.class)
+public class PersonRepositoryIntegrationTest {
+
+	@ClassRule public static RequiresMongoDB mongodbAvailable = RequiresMongoDB.anyVersion();
+
+	@Autowired PersonRepository repository;
+	@Autowired MongoOperations operations;
+
+	Person dave, oliver, carter, admin;
+
+	@Before
+	public void setUp() {
+
+		repository.deleteAll();
+
+		admin = repository.save(new Person("Admin", "Boss"));
+		dave = repository.save(new Person("Dave", "Matthews"));
+		oliver = repository.save(new Person("Oliver August", "Matthews"));
+		carter = repository.save(new Person("Carter", "Beauford"));
+	}
+
+	@Test
+	public void nonAdminCallingShouldReturnOnlyItSelfAsPerson() throws Exception {
+		
+		SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(dave, "x"));
+
+		List<Person> persons = repository.findAllForCurrentUserById();
+		
+		assertThat(persons, hasSize(1));
+		assertThat(persons, contains(dave));
+	}
+
+	@Test
+	public void adminCallingShouldReturnAllUsers() throws Exception {
+
+		UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(admin, "x",
+				Collections.singleton(new SimpleGrantedAuthority("ROLE_ADMIN")));
+		SecurityContextHolder.getContext().setAuthentication(auth);
+
+		List<Person> persons = repository.findAllForCurrentUserById();
+		
+		assertThat(persons, hasSize(4));
+		assertThat(persons, containsInAnyOrder(admin, dave, carter, oliver));
+	}
+}

--- a/mongodb/security/src/test/java/example/springdata/mongodb/people/package-info.java
+++ b/mongodb/security/src/test/java/example/springdata/mongodb/people/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Package showing usage of Spring Data MongoDB Repositories with Java 8.
+ */
+package example.springdata.mongodb.people;
+


### PR DESCRIPTION
Initial project and with example for dynamic data filtering based on current security context information.

Relies on DATAMONGO-1244 to be resolved.