### PR TITLE
Issue/datacmns 669

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -12,6 +12,11 @@
 		<version>1.0.0.BUILD-SNAPSHOT</version>
 	</parent>
 
+	<properties>
+		<angularjs.version>1.4.2</angularjs.version>
+		<trNgGrid.version>3.1.2</trNgGrid.version>
+	</properties>
+		
 	<dependencies>
 
 		<dependency>
@@ -37,6 +42,18 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>angularjs</artifactId>
+			<version>${angularjs.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>trNgGrid</artifactId>
+			<version>${trNgGrid.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/web/src/main/java/example/users/User.java
+++ b/web/src/main/java/example/users/User.java
@@ -21,6 +21,9 @@ import javax.persistence.Id;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -41,8 +44,8 @@ import lombok.RequiredArgsConstructor;
 public class User {
 
 	private @GeneratedValue @Id Long id;
-	private final Username username;
-	private final Password password;
+	private @JsonUnwrapped final Username username;
+	private @JsonIgnore final Password password;
 
 	User() {
 		this.username = null;

--- a/web/src/main/java/example/users/Username.java
+++ b/web/src/main/java/example/users/Username.java
@@ -18,6 +18,7 @@ package example.users;
 import javax.persistence.Embeddable;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 import org.springframework.util.StringUtils;
 
@@ -30,7 +31,7 @@ import org.springframework.util.StringUtils;
 @Embeddable
 public class Username {
 
-	private final String username;
+	private @Getter final String username;
 
 	Username() {
 		this.username = null;

--- a/web/src/main/java/example/users/web/UserRestController.java
+++ b/web/src/main/java/example/users/web/UserRestController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.users.web;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.view.RedirectView;
+
+import example.users.User;
+import example.users.UserManagement;
+
+/**
+ * A sample controller implementation to showcase Spring Data web support:
+ * <ol>
+ * <li>Automatic population of Specification objects.</li>
+ * </ol>
+ * 
+ * TODO Don't think that a RestController is necessary, but i didn't want to mess around with the original controller.
+ * TODO Add the actual specification parameter to the list of parametersof {@link #users}.
+ * 
+ * @author Michael J. Simons
+ */
+@RestController
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequestMapping("/users")
+public class UserRestController {
+	
+	private final UserManagement userManagement;
+
+	/**
+	 * Returns a {@link Page} of {@link User}s. Spring Data automatically populates the {@link Pageable} from
+	 * request data according to the setup of {@link PageableHandlerMethodArgumentResolver}. Note how the defaults can be
+	 * tweaked by using {@link PageableDefault}.
+	 * 
+	 * @param pageable will never be {@literal null}.
+	 * @return
+	 */	
+	@RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+	public Page<User> users(@PageableDefault(size = 5) Pageable pageable) {
+		return userManagement.findAll(pageable);
+	}
+}

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.thymeleaf.cache = false

--- a/web/src/main/resources/static/js/users.js
+++ b/web/src/main/resources/static/js/users.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var controllers = angular
+	.module('controllers', [])
+	.controller('UsersCtrl', function($scope, $http, $routeParams) {	    
+		$scope.foobar = 'xads';			
+	    $scope.onServerSideItemsRequested = function(currentPage, pageItems, filterByFields, orderBy, orderByReverse) {
+			var params = {
+			    page: currentPage,
+			    pageSize: pageItems,
+			    orderBy: typeof orderBy === "undefined" ? null : orderBy,
+			    orderByDirection: orderByReverse ? 'ASC' : 'DESC'
+			};
+			for (var prop in filterByFields) {
+			    params[prop] = filterByFields[prop];		    
+			}		
+			$http.get('/users', {params: params}).success(function(data) {
+			    $scope.page = data;
+			});
+	    };
+	});
+
+var pfmpro = angular
+	.module('spring-data-web-example', ['ngRoute', 'trNgGrid', 'controllers'])
+	.run();

--- a/web/src/main/resources/templates/users.html
+++ b/web/src/main/resources/templates/users.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-4.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org"  data-ng-app="spring-data-web-example">
 	<head>
 		<title>Users</title>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css" />
 		<link rel="stylesheet" th:href="@{/css/style.css}" type="text/css" />
+		<link rel="stylesheet" th:href="@{/webjars/trNgGrid/3.1.2/trNgGrid.min.css}" type="text/css" />
+		<script type="text/javascript" th:src="@{/webjars/angularjs/1.4.2/angular.min.js}"></script>
+		<script type="text/javascript" th:src="@{/webjars/angularjs/1.4.2/angular-route.min.js}"></script>
+		<script type="text/javascript" th:src="@{/webjars/trNgGrid/3.1.2/trNgGrid.min.js}"></script>
+		<script type="text/javascript" th:src="@{/js/users.js}"></script>		
 	</head>
 	<body>
 		<h1>Users</h1>
@@ -49,5 +54,31 @@
 			</div>
 			<input type="submit" class="btn btn-default" value="Register user" />
 		</form>
+		
+		<hr />
+		<div data-ng-controller="UsersCtrl">
+			<div class="table-responsive">
+			    <table tr-ng-grid=""
+				   items="page.content" 
+				   page-items="page.size" 
+				   total-items="page.totalElements" 
+				   selection-mode="SingleRow"
+				   enable-filtering="false"
+				   locale="de-de"
+				   order-by="page.sort[0].property"
+				   filter-by="additionalParams.onlyActive"
+				   order-by-reverse="true"
+				   on-data-required="onServerSideItemsRequested(currentPage, pageItems, filterByFields, orderBy, orderByReverse)"
+				   on-data-required-delay="500"
+				   >
+					<thead>
+					    <tr>		    
+						<th field-name="username" enable-filtering="true" />
+						<th field-name="password" enable-filtering="true"/>								   
+					    </tr>
+					</thead>    						
+		    	</table>
+			</div>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
Hello,

this is a proposal to show case the dynamic specification generation of DATACMNS-669. 

It adds a AngularJS table based on [trNgGrid](https://github.com/MoonStorm/trNgGrid). If you type in something into the filter boxes, you should see the corresponding request parameter appear in the web inspector.

I'm not a lombok user and i actually don't understand why username and password are constructed via embeddables. I modified Username to generate a Getter and User to unwrap the username so that i had some "sane" JSON delivered by the new UserRestController, which is the place where i would put the upcoming Specification parameter.

All dependencies are still managed by maven (brought in via web jars), you don't need any JavaScript build tool.

Thanks,
Michael.
