### PR TITLE
#120 - Add missing main method to multi-store REST example.

### DIFF
--- a/rest/multi-store/src/main/java/example/springdata/multistore/Application.java
+++ b/rest/multi-store/src/main/java/example/springdata/multistore/Application.java
@@ -15,6 +15,7 @@
  */
 package example.springdata.multistore;
 
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
@@ -24,4 +25,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @author Oliver Gierke
  */
 @SpringBootApplication
-public class Application {}
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}


### PR DESCRIPTION
Previously a `mvn clean install` in the SD-examples root failed because the Application
class in the multi-store example was missing a main method that is required by the spring-boot maven plugin.