### PR TITLE
#309 - QueryDSL Web Example fails when Predicate is null

### DIFF
--- a/web/querydsl/src/main/java/example/users/UserRepository.java
+++ b/web/querydsl/src/main/java/example/users/UserRepository.java
@@ -18,7 +18,7 @@ package example.users;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 import com.querydsl.core.types.dsl.StringPath;
 
@@ -31,7 +31,7 @@ import com.querydsl.core.types.dsl.StringPath;
  * @author Oliver Gierke
  */
 public interface UserRepository
-		extends CrudRepository<User, String>, QuerydslPredicateExecutor<User>, QuerydslBinderCustomizer<QUser> {
+		extends PagingAndSortingRepository<User, String>, QuerydslPredicateExecutor<User>, QuerydslBinderCustomizer<QUser> {
 
 	/*
 	 * (non-Javadoc)

--- a/web/querydsl/src/main/java/example/users/web/UserController.java
+++ b/web/querydsl/src/main/java/example/users/web/UserController.java
@@ -54,7 +54,13 @@ class UserController {
 		builder.replaceQueryParam("page", new Object[0]);
 
 		model.addAttribute("baseUri", builder.build().toUri());
-		model.addAttribute("users", repository.findAll(predicate, pageable));
+
+		if(predicate == null)
+		{
+			model.addAttribute("users", repository.findAll(pageable));
+		} else {
+			model.addAttribute("users", repository.findAll(predicate, pageable));
+		}
 
 		return "index";
 	}


### PR DESCRIPTION
#309

I'll use PagingAndSortingRepository in order to search without Predicate.