### PR TITLE
Fix Hibernate exclusion in EclipseLink sample

### DIFF
--- a/jpa/eclipselink/pom.xml
+++ b/jpa/eclipselink/pom.xml
@@ -27,7 +27,7 @@
 			<exclusions>
 				<exclusion>
 					<groupId>org.hibernate</groupId>
-					<artifactId>hibernate-entitymanager</artifactId>
+					<artifactId>hibernate-core</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>


### PR DESCRIPTION
Previously deprecated hibernate-entitymanager was excluded that was not taking effect, since current spring-boot-starter-data-jpa depends on hibernate-core