### PR TITLE
Bom example: fix gradle build plus a little more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ target/
 #IntelliJ Stuff
 .idea
 *.iml
+
+# gradle stuff
+build/
+.gradle/

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'io.spring.gradle:dependency-management-plugin:0.5.0.RELEASE'
+		classpath 'io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE'
 	}
 }
 

--- a/bom/build.gradle
+++ b/bom/build.gradle
@@ -11,8 +11,8 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: 'java'
 
 ext {
-	springVersion = '4.1.6.RELEASE'
-	springDataVersion = 'Fowler-RELEASE'
+	springVersion = '5.0.2.RELEASE'
+	springDataVersion = 'Kay-SR2'
 }
 
 repositories {


### PR DESCRIPTION
- the gradle build was failing with 
    > Failed to apply plugin [id 'io.spring.dependency-management']
    > Could not create task of type 'DependencyManagementReportTask'.

- upgrade the versions of spring in build.gradle to keep them in sync with those declared in maven's pom

- update the .gitignore file with gradle dirs