### PR TITLE
#349 - Fix and simplify DataAccessStrategy construction.

### DIFF
--- a/jdbc/basics/README.adoc
+++ b/jdbc/basics/README.adoc
@@ -1,6 +1,5 @@
 == Spring Data JDBC basics
 
-
 === SimpleEntityTests
 
 This example demonstrate basic usage of JDBC based repositories.
@@ -26,3 +25,6 @@ This is achieved by providing a custom `NamingStrategy` which maps both to the s
 
 * When the database returns a data type for query which Spring Data JDBC doesn't map out of the box a custom conversion can be registered using a `ConversionCustomizer` as demonstrated in `AggregateContext.conversionCustomizer()`.
 
+* `LegoSetRepository` has methods that utilize `@Query` annotations.
+
+* Note that `Model` is a value class, i.e. it is immutable, and doesn't have an ID.

--- a/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/AggregateConfiguration.java
+++ b/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/AggregateConfiguration.java
@@ -140,21 +140,4 @@ public class AggregateConfiguration {
 			}
 		});
 	}
-
-	// temporary workaround for https://jira.spring.io/browse/DATAJDBC-155
-	@Bean
-	DataAccessStrategy defaultDataAccessStrategy(JdbcMappingContext context, DataSource dataSource) {
-
-		NamedParameterJdbcOperations operations = new NamedParameterJdbcTemplate(dataSource);
-		DelegatingDataAccessStrategy accessStrategy = new DelegatingDataAccessStrategy();
-
-		accessStrategy.setDelegate(new DefaultDataAccessStrategy( //
-				new SqlGeneratorSource(context), //
-				operations, //
-				context, //
-				accessStrategy) //
-		);
-
-		return accessStrategy;
-	}
 }

--- a/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/AggregateConfiguration.java
+++ b/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/AggregateConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.data.jdbc.core.DataAccessStrategy;
 import org.springframework.data.jdbc.core.DefaultDataAccessStrategy;
 import org.springframework.data.jdbc.core.DelegatingDataAccessStrategy;
 import org.springframework.data.jdbc.core.SqlGeneratorSource;
+import org.springframework.data.jdbc.mapping.event.AfterSave;
 import org.springframework.data.jdbc.mapping.event.BeforeSave;
 import org.springframework.data.jdbc.mapping.model.ConversionCustomizer;
 import org.springframework.data.jdbc.mapping.model.DefaultNamingStrategy;
@@ -48,31 +49,30 @@ import org.springframework.lang.Nullable;
 @Configuration
 @EnableJdbcRepositories
 public class AggregateConfiguration {
+	final AtomicInteger id = new AtomicInteger(0);
 
 	@Bean
 	public ApplicationListener<?> idSetting() {
 
-		final AtomicInteger id = new AtomicInteger(0);
-
 		return (ApplicationListener<BeforeSave>) event -> {
 
-			Object entity = event.getEntity();
-
-			if (entity instanceof LegoSet) {
-
-				LegoSet legoSet = (LegoSet) entity;
-
-				if (legoSet.getId() == 0) {
-					legoSet.setId(id.incrementAndGet());
-				}
-
-				Manual manual = legoSet.getManual();
-
-				if (manual != null) {
-					manual.setId((long) legoSet.getId());
-				}
+			if (event.getEntity() instanceof LegoSet) {
+				setIds((LegoSet) event.getEntity());
 			}
 		};
+	}
+
+	private void setIds(LegoSet legoSet) {
+
+		if (legoSet.getId() == 0) {
+			legoSet.setId(id.incrementAndGet());
+		}
+
+		Manual manual = legoSet.getManual();
+
+		if (manual != null) {
+			manual.setId((long) legoSet.getId());
+		}
 	}
 
 	@Bean

--- a/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/LegoSet.java
+++ b/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/LegoSet.java
@@ -77,10 +77,7 @@ public class LegoSet {
 
 	public void addModel(String name, String description) {
 
-		Model model = new Model();
-		model.name = name;
-		model.description = description;
-
+		Model model = new Model(name, description);
 		models.put(name, model);
 	}
 }

--- a/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/LegoSetRepository.java
+++ b/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/LegoSetRepository.java
@@ -15,11 +15,28 @@
  */
 package example.springdata.jdbc.basics.aggregate;
 
+import org.springframework.data.jdbc.repository.query.Modifying;
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 /**
  * A repository for {@link LegoSet}.
  *
  * @author Jens Schauder
  */
-interface LegoSetRepository extends CrudRepository<LegoSet, Integer> {}
+interface LegoSetRepository extends CrudRepository<LegoSet, Integer> {
+
+	@Query("SELECT m.name modelName, m.description, l.name setName" +
+			"  FROM model m" +
+			"  JOIN LegoSet l" +
+			"  ON m.legoset = l.id" +
+			"  WHERE :age BETWEEN l.minAge and l.maxAge")
+	List<ModelReport> reportModelForAge(@Param("age") int age);
+
+	@Modifying
+	@Query("UPDATE model set name = lower(name) WHERE name <> lower(name)")
+	int lowerCaseMapKeys();
+}

--- a/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/ModelReport.java
+++ b/jdbc/basics/src/main/java/example/springdata/jdbc/basics/aggregate/ModelReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,12 @@ package example.springdata.jdbc.basics.aggregate;
 import lombok.Value;
 
 /**
- * One of potentially multiple models that can be build from a single {@link LegoSet}. No getters or setters needed.
- *
  * @author Jens Schauder
  */
 @Value
-public class Model {
+public class ModelReport {
 
-	String name;
-	String description;
+	private final String modelName;
+	private final String description;
+	private final String setName;
 }

--- a/jdbc/basics/src/main/java/example/springdata/jdbc/basics/simpleentity/CategoryConfiguration.java
+++ b/jdbc/basics/src/main/java/example/springdata/jdbc/basics/simpleentity/CategoryConfiguration.java
@@ -66,21 +66,4 @@ public class CategoryConfiguration {
 			}
 		};
 	}
-
-	// temporary workaround for https://jira.spring.io/browse/DATAJDBC-155
-	@Bean
-	DataAccessStrategy defaultDataAccessStrategy(JdbcMappingContext context, DataSource dataSource) {
-
-		NamedParameterJdbcOperations operations = new NamedParameterJdbcTemplate(dataSource);
-		DelegatingDataAccessStrategy accessStrategy = new DelegatingDataAccessStrategy();
-
-		accessStrategy.setDelegate(new DefaultDataAccessStrategy( //
-				new SqlGeneratorSource(context), //
-				operations, //
-				context, //
-				accessStrategy) //
-		);
-
-		return accessStrategy;
-	}
 }

--- a/jdbc/basics/src/test/java/example/springdata/jdbc/basics/aggregate/AggregateTests.java
+++ b/jdbc/basics/src/test/java/example/springdata/jdbc/basics/aggregate/AggregateTests.java
@@ -15,15 +15,21 @@
  */
 package example.springdata.jdbc.basics.aggregate;
 
+import static org.assertj.core.api.Assertions.*;
+
 import example.springdata.jdbc.basics.Output;
 
 import java.time.Period;
+import java.util.Arrays;
+import java.util.List;
 
+import org.assertj.core.groups.Tuple;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureJdbc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -34,6 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = AggregateConfiguration.class)
 @AutoConfigureJdbc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class AggregateTests {
 
 	@Autowired LegoSetRepository repository;
@@ -41,34 +48,88 @@ public class AggregateTests {
 	@Test
 	public void exerciseSomewhatComplexEntity() {
 
-		LegoSet smallCar = createLegoSet();
+		LegoSet smallCar = createLegoSet("Small Car 01", 5, 12);
 		smallCar.setManual(new Manual("Just put all the pieces together in the right order", "Jens Schauder"));
 		smallCar.addModel("suv", "SUV with sliding doors.");
 		smallCar.addModel("roadster", "Slick red roadster.");
 
 		repository.save(smallCar);
-		Output.list(repository.findAll(), "Original LegoSet");
+		Iterable<LegoSet> legoSets = repository.findAll();
+		Output.list(legoSets, "Original LegoSet");
+		checkLegoSets(legoSets, "Just put all the pieces together in the right order", 2);
 
 		smallCar.getManual().setText("Just make it so it looks like a car.");
 		smallCar.addModel("pickup", "A pickup truck with some tools in the back.");
 
 		repository.save(smallCar);
-		Output.list(repository.findAll(), "Updated");
+		legoSets = repository.findAll();
+		Output.list(legoSets, "Updated");
+		checkLegoSets(legoSets, "Just make it so it looks like a car.", 3);
 
 		smallCar.setManual(new Manual("One last attempt: Just build a car! Ok?", "Jens Schauder"));
 
 		repository.save(smallCar);
-		Output.list(repository.findAll(), "Manual replaced");
+		legoSets = repository.findAll();
+		Output.list(legoSets, "Manual replaced");
+		checkLegoSets(legoSets, "One last attempt: Just build a car! Ok?", 3);
+
 	}
 
-	private LegoSet createLegoSet() {
+	@Test
+	public void customQueries() {
+
+		LegoSet smallCars = createLegoSet("Small Car - 01", 5, 10);
+		smallCars.setManual(new Manual("Just put all the pieces together in the right order", "Jens Schauder"));
+
+		smallCars.addModel("SUV", "SUV with sliding doors.");
+		smallCars.addModel("roadster", "Slick red roadster.");
+
+		LegoSet f1Racer = createLegoSet("F1 Racer", 6, 15);
+		f1Racer.setManual(new Manual("Build a helicopter or a plane", "M. Shoemaker"));
+
+		f1Racer.addModel("F1 Ferrari 2018", "A very fast red car.");
+
+		LegoSet constructionVehicles = createLegoSet("Construction Vehicles", 3, 6);
+		constructionVehicles.setManual(
+				new Manual("Build a Road Roler, a Mobile Crane, a Tracked Dumper, or a Backhoe Loader ", "Bob the Builder"));
+
+		constructionVehicles.addModel("scoop", "A backhoe loader");
+		constructionVehicles.addModel("Muck", "Muck is a continuous tracked dump truck with an added bulldozer blade");
+		constructionVehicles.addModel("lofty", "A mobile crane");
+		constructionVehicles.addModel("roley",
+				"A road roller that loves to make up songs and frequently spins his eyes when he is excited.");
+
+		repository.saveAll(Arrays.asList(smallCars, f1Racer, constructionVehicles));
+
+		List<ModelReport> report = repository.reportModelForAge(6);
+		Output.list(report, "Model Report");
+
+		assertThat(report).hasSize(7)
+				.allMatch(m -> m.getDescription() != null && m.getModelName() != null && m.getSetName() != null);
+
+		int updated = repository.lowerCaseMapKeys();
+		// SUV, F1 Ferrari 2018 and Muck get updated
+		assertThat(updated).isEqualTo(3);
+
+	}
+
+	private LegoSet createLegoSet(String name, int minimumAge, int maximumAge) {
 
 		LegoSet smallCar = new LegoSet();
 
-		smallCar.setName("Small Car 01");
-		smallCar.setMinimumAge(Period.ofYears(5));
-		smallCar.setMaximumAge(Period.ofYears(12));
+		smallCar.setName(name);
+		smallCar.setMinimumAge(Period.ofYears(minimumAge));
+		smallCar.setMaximumAge(Period.ofYears(maximumAge));
 
 		return smallCar;
+	}
+
+	private void checkLegoSets(Iterable<LegoSet> legoSets, String manualText, int numberOfModels) {
+
+		assertThat(legoSets) //
+				.extracting( //
+						ls -> ls.getManual().getText(), //
+						ls -> ls.getModels().size()) //
+				.containsExactly(new Tuple(manualText, numberOfModels));
 	}
 }

--- a/jdbc/mybatis/src/main/java/example/springdata/jdbc/mybatis/MyBatisConfiguration.java
+++ b/jdbc/mybatis/src/main/java/example/springdata/jdbc/mybatis/MyBatisConfiguration.java
@@ -15,23 +15,13 @@
  */
 package example.springdata.jdbc.mybatis;
 
-import static java.util.Arrays.*;
-
-import javax.sql.DataSource;
-
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jdbc.core.CascadingDataAccessStrategy;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
-import org.springframework.data.jdbc.core.DefaultDataAccessStrategy;
-import org.springframework.data.jdbc.core.DelegatingDataAccessStrategy;
-import org.springframework.data.jdbc.core.SqlGeneratorSource;
 import org.springframework.data.jdbc.mapping.model.JdbcMappingContext;
 import org.springframework.data.jdbc.mybatis.MyBatisDataAccessStrategy;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 /**
  * @author Jens Schauder
@@ -40,27 +30,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 @EnableJdbcRepositories
 public class MyBatisConfiguration {
 
-	// temporary workaround for https://jira.spring.io/browse/DATAJDBC-155
 	@Bean
-	DataAccessStrategy defaultDataAccessStrategy(JdbcMappingContext context, DataSource dataSource,
-			SqlSession sqlSession) {
-
-		NamedParameterJdbcOperations operations = new NamedParameterJdbcTemplate(dataSource);
-
-		DelegatingDataAccessStrategy delegatingDataAccessStrategy = new DelegatingDataAccessStrategy();
-		MyBatisDataAccessStrategy myBatisDataAccessStrategy = new MyBatisDataAccessStrategy(sqlSession);
-
-		CascadingDataAccessStrategy cascadingDataAccessStrategy = new CascadingDataAccessStrategy(
-				asList(myBatisDataAccessStrategy, delegatingDataAccessStrategy));
-
-		DefaultDataAccessStrategy defaultDataAccessStrategy = new DefaultDataAccessStrategy( //
-				new SqlGeneratorSource(context), //
-				operations, //
-				context, //
-				cascadingDataAccessStrategy);
-
-		delegatingDataAccessStrategy.setDelegate(defaultDataAccessStrategy);
-
-		return cascadingDataAccessStrategy;
+	DataAccessStrategy defaultDataAccessStrategy(JdbcMappingContext context, SqlSession sqlSession) {
+		return MyBatisDataAccessStrategy.createCombinedAccessStrategy(context, sqlSession);
 	}
 }

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -43,6 +43,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jdbc</artifactId>
+			<version>1.0.0.DATAJDBC-155-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
DO NOT MERGE. NEEDS REBASING AFTER #346 IS MERGED.
Spring Data Jdbc does create a DefaultDataAccessStrategy by default.
No need to do it in the examples.

Also, MyBatisDataAccessStrategy offers a factory method to create an appropriate DataAccessStrategy in the presence of MyBatis.