### PR TITLE
#386 - Add integration test for deep nested derived queries support.

### DIFF
--- a/neo4j/example/src/main/java/example/springdata/neo4j/Actor.java
+++ b/neo4j/example/src/main/java/example/springdata/neo4j/Actor.java
@@ -19,12 +19,12 @@ package example.springdata.neo4j;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
 
@@ -33,16 +33,20 @@ import org.neo4j.ogm.annotation.Relationship;
  *
  * @author Luanne Misquitta
  * @author Oliver Gierke
+ * @author Michael J. Simons
  */
 @NodeEntity(label = "Actor")
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
-@RequiredArgsConstructor
 @Getter
 public class Actor {
 
-	private @GraphId Long id;
-	private final String name;
-	private final @Relationship(type = "ACTED_IN") Set<Role> roles = new HashSet<>();
+	private @Id @GeneratedValue Long id;
+	private String name;
+	private @Relationship(type = "ACTED_IN") Set<Role> roles = new HashSet<>();
+
+	public Actor(String name) {
+		this.name = name;
+	}
 
 	public void actedIn(Movie movie, String roleName) {
 

--- a/neo4j/example/src/main/java/example/springdata/neo4j/ActorRepository.java
+++ b/neo4j/example/src/main/java/example/springdata/neo4j/ActorRepository.java
@@ -15,11 +15,22 @@
  */
 package example.springdata.neo4j;
 
+import java.util.List;
+
 import org.springframework.data.neo4j.repository.Neo4jRepository;
 
 /**
- * {@link GraphRepository} for {@link Actor}s.
+ * {@link Neo4jRepository} for {@link Actor actors}.
  *
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
-public interface ActorRepository extends Neo4jRepository<Actor, Long> {}
+public interface ActorRepository extends Neo4jRepository<Actor, Long> {
+	/**
+	 * Nested property from select from roles -> movie -> title,
+	 * where this here represents the start node in a relationship and movie the end node.
+	 * @param title
+	 * @return
+	 */
+	List<Actor> findAllByRolesMovieTitle(String title);
+}

--- a/neo4j/example/src/main/java/example/springdata/neo4j/Movie.java
+++ b/neo4j/example/src/main/java/example/springdata/neo4j/Movie.java
@@ -19,12 +19,12 @@ package example.springdata.neo4j;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
 
@@ -33,14 +33,18 @@ import org.neo4j.ogm.annotation.Relationship;
  *
  * @author Luanne Misquitta
  * @author Oliver Gierke
+ * @author Michael J. Simons
  */
 @NodeEntity(label = "Movie")
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
-@RequiredArgsConstructor
 @Getter
 public class Movie {
 
-	private @GraphId Long id;
-	private final String title;
-	private final @Relationship(type = "ACTED_IN", direction = "INCOMING") Set<Role> roles = new HashSet<>();
+	private @Id @GeneratedValue Long id;
+	private String title;
+	private @Relationship(type = "ACTED_IN", direction = "INCOMING") Set<Role> roles = new HashSet<>();
+
+	public Movie(String title) {
+		this.title = title;
+	}
 }

--- a/neo4j/example/src/main/java/example/springdata/neo4j/Role.java
+++ b/neo4j/example/src/main/java/example/springdata/neo4j/Role.java
@@ -18,10 +18,10 @@ package example.springdata.neo4j;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import org.neo4j.ogm.annotation.EndNode;
-import org.neo4j.ogm.annotation.GraphId;
+import org.neo4j.ogm.annotation.GeneratedValue;
+import org.neo4j.ogm.annotation.Id;
 import org.neo4j.ogm.annotation.RelationshipEntity;
 import org.neo4j.ogm.annotation.StartNode;
 
@@ -29,15 +29,21 @@ import org.neo4j.ogm.annotation.StartNode;
  * A Role relationship entity between an actor and movie.
  *
  * @author Luanne Misquitta
+ * @author Michael J. Simons
  */
 @RelationshipEntity(type = "ACTED_IN")
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
-@RequiredArgsConstructor
 @Getter
 public class Role {
 
-	private @GraphId Long id;
-	private final @StartNode Actor actor;
-	private final String role;
-	private final @EndNode Movie movie;
+	private @Id @GeneratedValue Long id;
+	private @StartNode Actor actor;
+	private String role;
+	private @EndNode Movie movie;
+
+	Role(Actor actor, String role, Movie movie) {
+		this.actor = actor;
+		this.role = role;
+		this.movie = movie;
+	}
 }


### PR DESCRIPTION
SDN supports derived queries over several, deeply nested properties in the following version combinations:
- Spring Data Kay SR9 + Neo4j-OGM 3.0.4
- Spring Data Lovelace RC1 + Neo4j-OGM 3.1.1

I want to make sure with that we are on a supported combination. As there is nothing comparable in Spring Boot, I hope this is the right place to add.

I had to touch all the domain classes used in the Neo4j example, because we don't support final fields for relationships, sorry for that.

The way I computed the version of Spring Boot is maybe also debatable. If you got a better idea, I'd love to know about that. Maybe someone can add some Maven / Profile magic to solve that in a better way.