### PR TITLE
Update redis/repositories example to use application.properties config

### DIFF
--- a/redis/repositories/src/main/java/example/springdata/redis/repositories/ApplicationConfiguration.java
+++ b/redis/repositories/src/main/java/example/springdata/redis/repositories/ApplicationConfiguration.java
@@ -23,24 +23,11 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 /**
+ * Redis connection, template, etc autoconfigured via application.properties
  * @author Christoph Strobl
  * @author Mark Paluch
  */
 @Configuration
 @EnableRedisRepositories
 public class ApplicationConfiguration {
-
-	@Bean
-	RedisConnectionFactory connectionFactory() {
-		return new LettuceConnectionFactory();
-	}
-
-	@Bean
-	RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory connectionFactory) {
-
-		RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
-		template.setConnectionFactory(connectionFactory);
-
-		return template;
-	}
 }

--- a/redis/repositories/src/main/resources/application.properties
+++ b/redis/repositories/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.data.redis.repositories.enabled=true # Whether to enable Redis repositories.
+spring.redis.host=localhost # Redis server host, default localhost
+spring.redis.port=6379 # Redis server port. default 6379


### PR DESCRIPTION
Modernization no longer requires custom @Bean configuration

Closes #396