### PR TITLE
Add examples for Kotlin usage with MongoDB and Cassandra

### DIFF
--- a/cassandra/kotlin/README.md
+++ b/cassandra/kotlin/README.md
@@ -1,0 +1,59 @@
+# Spring Data Cassandra - Kotlin examples
+
+This project contains samples of Kotlin-specific features of Spring Data (Cassandra).
+
+## Value defaulting on entity construction
+
+Kotlin allows defaulting for constructor- and method arguments. 
+Defaulting allows usage of substitute values if a field in the document is absent or simply `null`. 
+Spring Data inspects objects whether they are Kotlin types and uses the appropriate constructor.
+
+```kotlin
+@Table
+data class Person(@PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED) val firstname: String? = "", val lastname: String = "White")
+
+operations.cqlOperations.execute(QueryBuilder.insertInto("person").value("firstname", "Walter"))
+
+val person = operations.query<Person>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.firstValue()!!
+
+assertThat(person.lastname).isEqualTo("White")
+```
+
+## Kotlin Extensions
+
+Spring Data exposes methods accepting a target type to either query for or to project results values on. 
+Kotlin represents classes with its own type, `KClass` which can be an obstacle when attempting to obtain a Java `Class` type.
+
+Spring Data ships with extensions that add overloads for methods accepting a type parameter by either leveraging generics or accepting `KClass` directly.
+
+```kotlin
+operations.getTableName<Person>()
+ 
+operations.getTableName(Person::class)
+```
+
+## Nullability
+
+Declaring repository interfaces using Kotlin allows expressing nullability constraints on arguments and return types. Spring Data evaluates nullability of arguments and return types and reacts to these. Passing `null` to a non-nullable argument raises an `IllegalArgumentException`, as you're already used to from Kotlin. Spring Data helps you also to prevent `null` in query results. If you wish to return a nullable result, use Kotlin's nullability marker `?`. To prevent `null` results, declare the return type of a query method as non-nullable. In the case a query yields no result, a non-nullable query method throws `EmptyResultDataAccessException`.  
+
+```kotlin
+interface PersonRepository : CrudRepository<Person, String> {
+
+	/**
+	 * Query method declaring a nullable return type that allows to return null values.
+	 */
+	fun findOneOrNoneByFirstname(firstname: String): Person?
+
+	/**
+	 * Query method declaring a nullable argument.
+	 */
+	fun findNullableByFirstname(firstname: String?): Person?
+
+	/**
+	 * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
+	 */
+	fun findOneByFirstname(firstname: String): Person
+}
+```

--- a/cassandra/kotlin/pom.xml
+++ b/cassandra/kotlin/pom.xml
@@ -1,0 +1,79 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.data.examples</groupId>
+		<artifactId>spring-data-cassandra-examples</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-data-cassandra-kotlin</artifactId>
+	<name>Spring Data Cassandra - Kotlin features</name>
+
+	<properties>
+		<spring-data-releasetrain.version>Lovelace-BUILD-SNAPSHOT</spring-data-releasetrain.version>
+	</properties>
+
+	<profiles>
+
+		<!-- Override property as the module always needs Lovelace -->
+
+		<profile>
+			<id>spring-data-next</id>
+			<properties>
+				<spring-data-releasetrain.version>Lovelace-BUILD-SNAPSHOT</spring-data-releasetrain.version>
+			</properties>
+		</profile>
+
+	</profiles>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-data-cassandra-example-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+		<testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<configuration>
+					<args>
+						<arg>-Xjsr305=strict</arg>
+					</args>
+					<compilerPlugins>
+						<plugin>spring</plugin>
+					</compilerPlugins>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/cassandra/kotlin/src/main/kotlin/example.springdata.cassandra.kotlin/ApplicationConfiguration.kt
+++ b/cassandra/kotlin/src/main/kotlin/example.springdata.cassandra.kotlin/ApplicationConfiguration.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.cassandra.kotlin
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * @author Mark Paluch
+ */
+@SpringBootApplication
+class ApplicationConfiguration
+
+fun main(args: Array<String>) {
+	runApplication<ApplicationConfiguration>(*args)
+}

--- a/cassandra/kotlin/src/main/kotlin/example.springdata.cassandra.kotlin/Person.kt
+++ b/cassandra/kotlin/src/main/kotlin/example.springdata.cassandra.kotlin/Person.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.cassandra.kotlin
+
+import org.springframework.data.cassandra.core.cql.PrimaryKeyType
+import org.springframework.data.cassandra.core.mapping.PrimaryKeyColumn
+import org.springframework.data.cassandra.core.mapping.Table
+
+/**
+ * An entity to represent a Person.
+ *
+ * @author Mark Paluch
+ */
+@Table
+data class Person(@PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED) val firstname: String? = "", val lastname: String = "White")

--- a/cassandra/kotlin/src/main/kotlin/example.springdata.cassandra.kotlin/PersonRepository.kt
+++ b/cassandra/kotlin/src/main/kotlin/example.springdata.cassandra.kotlin/PersonRepository.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.cassandra.kotlin
+
+import org.springframework.data.repository.CrudRepository
+
+/**
+ * Repository interface to manage [Person] instances.
+ *
+ * @author Mark Paluch
+ */
+interface PersonRepository : CrudRepository<Person, String> {
+
+	/**
+	 * Query method declaring a nullable return type that allows to return null values.
+	 */
+	fun findOneOrNoneByFirstname(firstname: String): Person?
+
+	/**
+	 * Query method declaring a nullable argument.
+	 */
+	fun findNullableByFirstname(firstname: String?): Person?
+
+	/**
+	 * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
+	 */
+	fun findOneByFirstname(firstname: String): Person
+}

--- a/cassandra/kotlin/src/main/resources/application.properties
+++ b/cassandra/kotlin/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.data.cassandra.keyspace-name=example
+spring.data.cassandra.schema-action=recreate

--- a/cassandra/kotlin/src/test/kotlin/example/springdata/cassandra/kotlin/RepositoryTests.kt
+++ b/cassandra/kotlin/src/test/kotlin/example/springdata/cassandra/kotlin/RepositoryTests.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.cassandra.kotlin
+
+import example.springdata.cassandra.util.CassandraKeyspace
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.data.util.Version
+import org.springframework.test.context.junit4.SpringRunner
+
+/**
+ * Tests showing Kotlin usage of Spring Data Repositories.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner::class)
+@SpringBootTest
+class RepositoryTests {
+
+	companion object {
+
+		@JvmField
+		@ClassRule
+		val CASSANDRA_KEYSPACE = CassandraKeyspace.onLocalhost()
+				.atLeast(Version.parse("3.0"))
+	}
+
+	@Autowired
+	lateinit var repository: PersonRepository
+
+	@Before
+	fun before() {
+		repository.deleteAll()
+	}
+
+	@Test
+	fun `should find one person`() {
+
+		repository.save(Person("Walter", "White"))
+
+		val walter = repository.findOneByFirstname("Walter")
+
+		assertThat(walter).isNotNull()
+		assertThat(walter.firstname).isEqualTo("Walter")
+		assertThat(walter.lastname).isEqualTo("White")
+	}
+
+	@Test
+	fun `should return null if no person found`() {
+
+		repository.save(Person("Walter", "White"))
+
+		val walter = repository.findOneOrNoneByFirstname("Hank")
+
+		assertThat(walter).isNull()
+	}
+
+	@Test
+	fun `should throw EmptyResultDataAccessException if no person found`() {
+
+		repository.save(Person("Walter", "White"))
+
+		assertThatThrownBy { repository.findOneByFirstname("Hank") }.isInstanceOf(EmptyResultDataAccessException::class.java)
+	}
+}

--- a/cassandra/kotlin/src/test/kotlin/example/springdata/cassandra/kotlin/TemplateTests.kt
+++ b/cassandra/kotlin/src/test/kotlin/example/springdata/cassandra/kotlin/TemplateTests.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.cassandra.kotlin
+
+import com.datastax.driver.core.Row
+import com.datastax.driver.core.querybuilder.QueryBuilder
+import example.springdata.cassandra.util.CassandraKeyspace
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.cassandra.core.*
+import org.springframework.data.cassandra.core.cql.CqlIdentifier
+import org.springframework.data.cassandra.core.query.Query.query
+import org.springframework.data.cassandra.core.query.isEqualTo
+import org.springframework.data.cassandra.core.query.where
+import org.springframework.data.util.Version
+import org.springframework.test.context.junit4.SpringRunner
+
+/**
+ * Tests showing Kotlin usage of [MongoTemplate] and its Kotlin extensions.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner::class)
+@SpringBootTest
+class TemplateTests {
+
+	companion object {
+
+		@JvmField
+		@ClassRule
+		val CASSANDRA_KEYSPACE = CassandraKeyspace.onLocalhost()
+				.atLeast(Version.parse("3.0"))
+	}
+
+	@Autowired
+	lateinit var operations: CassandraOperations
+
+	@Before
+	fun before() {
+		operations.truncate<Person>()
+	}
+
+	@Test
+	fun `should create collection leveraging reified type parameters`() {
+		assertThat(operations.getTableName<Person>()).isEqualTo(CqlIdentifier.of("person"))
+	}
+
+	@Test
+	fun `should insert and find person in a fluent API style`() {
+
+		operations.insert<Person>().inTable("person").one(Person("Walter", "White"))
+
+		val people = operations.query<Person>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.all()
+
+		assertThat(people).hasSize(1).extracting("firstname").containsOnly("Walter")
+	}
+
+	@Test
+	fun `should insert and project query results`() {
+
+		operations.insert<Person>().inTable("person").one(Person("Walter", "White"))
+
+		val firstnameOnly = operations.query<Person>()
+				.asType<FirstnameOnly>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.oneValue()
+
+		assertThat(firstnameOnly?.getFirstname()).isEqualTo("Walter")
+	}
+
+	@Test
+	fun `should insert and count objects in a fluent API style`() {
+
+		operations.insert<Person>().inTable("person").one(Person("Walter", "White"))
+
+		val count = operations.query<Person>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.count()
+
+		assertThat(count).isEqualTo(1)
+	}
+
+	@Test
+	fun `should insert and find person`() {
+
+		val person = Person("Walter", "White")
+
+		operations.insert(person)
+
+		val people = operations.select<Person>(query(where("firstname").isEqualTo("Walter")))
+
+		assertThat(people).hasSize(1).extracting("firstname").containsOnly("Walter")
+	}
+
+	@Test
+	fun `should apply defaulting for absent properties`() {
+
+		operations.cqlOperations.execute(QueryBuilder.insertInto("person").value("firstname", "Walter"))
+
+		val person = operations.query<Person>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.firstValue()!!
+
+		assertThat(person.firstname).isEqualTo("Walter")
+		assertThat(person.lastname).isEqualTo("White")
+
+
+		val resultSet = operations.cqlOperations.queryForResultSet("SELECT * FROM person WHERE firstname = 'Walter'")
+		val walter = resultSet.one()!!
+
+		assertThat(walter).isNotNull
+		assertThat(walter.getString("firstname")).isEqualTo("Walter")
+		assertThat(walter.getString("lastname")).isNull()
+	}
+
+	interface FirstnameOnly {
+		fun getFirstname(): String
+	}
+}

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,6 +20,7 @@
 		<module>util</module>
 		<module>example</module>
 		<module>java8</module>
+		<module>kotlin</module>
 		<module>reactive</module>
 	</modules>
 

--- a/mongodb/kotlin/README.md
+++ b/mongodb/kotlin/README.md
@@ -1,0 +1,56 @@
+# Spring Data MongoDB - Kotlin examples
+
+This project contains samples of Kotlin-specific features of Spring Data (MongoDB).
+
+## Value defaulting on entity construction
+
+Kotlin allows defaulting for constructor- and method arguments. 
+Defaulting allows usage of substitute values if a field in the document is absent or simply `null`. 
+Spring Data inspects objects whether they are Kotlin types and uses the appropriate constructor.
+
+```kotlin
+data class Person (@Id val id: String?, val firstname: String? = "Walter", val lastname: String)
+
+operations.insert<Document>().inCollection("person").one(Document("lastname", "White"))
+
+val walter = operations.findOne<Document>(query(where("lastname").isEqualTo("White")), "person")
+
+assertThat(walter.firstname).isEqualTo("Walter")
+```
+
+## Kotlin Extensions
+
+Spring Data exposes methods accepting a target type to either query for or to project results values on. 
+Kotlin represents classes with its own type, `KClass` which can be an obstacle when attempting to obtain a Java `Class` type.
+
+Spring Data ships with extensions that add overloads for methods accepting a type parameter by either leveraging generics or accepting `KClass` directly.
+
+```kotlin
+operations.getCollectionName<Person>()
+ 
+operations.getCollectionName(Person::class)
+```
+
+## Nullability
+
+Declaring repository interfaces using Kotlin allows expressing nullability constraints on arguments and return types. Spring Data evaluates nullability of arguments and return types and reacts to these. Passing `null` to a non-nullable argument raises an `IllegalArgumentException`, as you're already used to from Kotlin. Spring Data helps you also to prevent `null` in query results. If you wish to return a nullable result, use Kotlin's nullability marker `?`. To prevent `null` results, declare the return type of a query method as non-nullable. In the case a query yields no result, a non-nullable query method throws `EmptyResultDataAccessException`.  
+
+```kotlin
+interface PersonRepository : CrudRepository<Person, String> {
+
+	/**
+	 * Query method declaring a nullable return type that allows to return null values.
+	 */
+	fun findOneOrNoneByFirstname(firstname: String): Person?
+
+	/**
+	 * Query method declaring a nullable argument.
+	 */
+	fun findNullableByFirstname(firstname: String?): Person?
+
+	/**
+	 * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
+	 */
+	fun findOneByFirstname(firstname: String): Person
+}
+```

--- a/mongodb/kotlin/pom.xml
+++ b/mongodb/kotlin/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.data.examples</groupId>
+		<artifactId>spring-data-mongodb-examples</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-data-mongodb-kotlin</artifactId>
+	<name>Spring Data MongoDB - Kotlin features</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+		<testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<configuration>
+					<args>
+						<arg>-Xjsr305=strict</arg>
+					</args>
+					<compilerPlugins>
+						<plugin>spring</plugin>
+					</compilerPlugins>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/mongodb/kotlin/pom.xml
+++ b/mongodb/kotlin/pom.xml
@@ -11,6 +11,11 @@
 	<artifactId>spring-data-mongodb-kotlin</artifactId>
 	<name>Spring Data MongoDB - Kotlin features</name>
 
+	<!-- Fix not released yet -->
+	<properties>
+		<spring-data-releasetrain.version>Kay-BUILD-SNAPSHOT</spring-data-releasetrain.version>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>

--- a/mongodb/kotlin/src/main/kotlin/example/springdata/mongodb/people/ApplicationConfiguration.kt
+++ b/mongodb/kotlin/src/main/kotlin/example/springdata/mongodb/people/ApplicationConfiguration.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * @author Mark Paluch
+ */
+@SpringBootApplication
+class ApplicationConfiguration
+
+fun main(args: Array<String>) {
+	runApplication<ApplicationConfiguration>(*args)
+}

--- a/mongodb/kotlin/src/main/kotlin/example/springdata/mongodb/people/Person.kt
+++ b/mongodb/kotlin/src/main/kotlin/example/springdata/mongodb/people/Person.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.PersistenceConstructor
+
+/**
+ * An entity to represent a Person.
+ *
+ * @author Mark Paluch
+ */
+data class Person @PersistenceConstructor constructor(@Id val id: String?, val firstname: String? = "Walter", val lastname: String = "") {
+	constructor(firstname: String?, lastname: String) : this(null, firstname, lastname);
+}

--- a/mongodb/kotlin/src/main/kotlin/example/springdata/mongodb/people/PersonRepository.kt
+++ b/mongodb/kotlin/src/main/kotlin/example/springdata/mongodb/people/PersonRepository.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people
+
+import org.springframework.data.repository.CrudRepository
+
+/**
+ * Repository interface to manage [Person] instances.
+ *
+ * @author Mark Paluch
+ */
+interface PersonRepository : CrudRepository<Person, String> {
+
+	/**
+	 * Query method declaring a nullable return type that allows to return null values.
+	 */
+	fun findOneOrNoneByFirstname(firstname: String): Person?
+
+	/**
+	 * Query method declaring a nullable argument.
+	 */
+	fun findNullableByFirstname(firstname: String?): Person?
+
+	/**
+	 * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
+	 */
+	fun findOneByFirstname(firstname: String): Person
+}

--- a/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/RepositoryTests.kt
+++ b/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/RepositoryTests.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.test.context.junit4.SpringRunner
+
+/**
+ * Tests showing Kotlin usage of Spring Data Repositories.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner::class)
+@SpringBootTest
+class RepositoryTests {
+
+	@Autowired
+	lateinit var repository: PersonRepository
+
+	@Before
+	fun before() {
+		repository.deleteAll()
+	}
+
+	@Test
+	fun `should find one person`() {
+
+		repository.save(Person("Walter", "White"))
+
+		val walter = repository.findOneByFirstname("Walter")
+
+		assertThat(walter).isNotNull()
+		assertThat(walter.firstname).isEqualTo("Walter")
+		assertThat(walter.lastname).isEqualTo("White")
+	}
+
+	@Test
+	fun `should return null if no person found`() {
+
+		repository.save(Person("Walter", "White"))
+
+		val walter = repository.findOneOrNoneByFirstname("Hank")
+
+		assertThat(walter).isNull()
+	}
+
+	@Test
+	fun `should throw EmptyResultDataAccessException if no person found`() {
+
+		repository.save(Person("Walter", "White"))
+
+		assertThatThrownBy { repository.findOneByFirstname("Hank") }.isInstanceOf(EmptyResultDataAccessException::class.java)
+	}
+
+	@Test
+	fun `should accept nullable parameters`() {
+
+		repository.save(Person(null, "Heisenberg"))
+
+		val heisenberg = repository.findNullableByFirstname(null)
+
+		assertThat(heisenberg).isNotNull()
+		assertThat(heisenberg!!.lastname).isEqualTo("Heisenberg")
+	}
+}

--- a/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/TemplateTests.kt
+++ b/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/TemplateTests.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people
+
+import org.assertj.core.api.Assertions.assertThat
+import org.bson.Document
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.mongodb.core.*
+import org.springframework.data.mongodb.core.query.Criteria.where
+import org.springframework.data.mongodb.core.query.Query.query
+import org.springframework.data.mongodb.core.query.isEqualTo
+import org.springframework.test.context.junit4.SpringRunner
+
+/**
+ * Tests showing Kotlin usage of [MongoTemplate] and its Kotlin extensions.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner::class)
+@SpringBootTest
+class TemplateTests {
+
+	@Autowired
+	lateinit var operations: MongoOperations
+
+	@Before
+	fun before() {
+		operations.dropCollection<Person>()
+	}
+
+	@Test
+	fun `should create collection leveraging reified type parameters`() {
+
+		operations.createCollection<Person>()
+
+		assertThat(operations.collectionNames).contains("person")
+	}
+
+	@Test
+	fun `should insert and find person in a fluent API style`() {
+
+		operations.insert<Person>().inCollection("person").one(Person("Walter", "White"))
+
+		val people = operations.query<Person>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.all()
+
+		assertThat(people).hasSize(1).extracting("firstname").containsOnly("Walter")
+	}
+
+	@Test
+	fun `should insert and project query results`() {
+
+		operations.insert<Person>().inCollection("person").one(Person("Walter", "White"))
+
+		val firstnameOnly = operations.query<Person>()
+				.asType<FirstnameOnly>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.oneValue()
+
+		assertThat(firstnameOnly?.getFirstname()).isEqualTo("Walter")
+	}
+
+	@Test
+	fun `should insert and count objects in a fluent API style`() {
+
+		operations.insert<Person>().inCollection("person").one(Person("Walter", "White"))
+
+		val count = operations.query<Person>()
+				.matching(query(where("firstname").isEqualTo("Walter")))
+				.count()
+
+		assertThat(count).isEqualTo(1)
+	}
+
+	@Test
+	fun `should insert and find person`() {
+
+		val person = Person("Walter", "White")
+
+		operations.insert(person)
+
+		val people = operations.find<Person>(query(where("firstname").isEqualTo("Walter")))
+
+		assertThat(people).hasSize(1).extracting("firstname").containsOnly("Walter")
+	}
+
+	@Test
+	fun `should apply defaulting for absent properties`() {
+
+		operations.insert<Document>().inCollection("person").one(Document("lastname", "White"))
+
+		val person = operations.query<Person>()
+				.matching(query(where("lastname").isEqualTo("White")))
+				.firstValue()!!
+
+		assertThat(person.firstname).isEqualTo("Walter")
+		assertThat(person.lastname).isEqualTo("White")
+
+
+		val walter = operations.findOne<Document>(query(where("lastname").isEqualTo("White")), "person")
+
+		assertThat(walter).isNotNull.containsEntry("lastname", "White").containsOnlyKeys("_id", "lastname")
+	}
+
+	interface FirstnameOnly {
+		fun getFirstname(): String
+	}
+}

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -24,6 +24,7 @@
 		<module>geo-json</module>
 		<module>gridfs</module>
 		<module>java8</module>
+		<module>kotlin</module>
 		<module>query-by-example</module>
 		<module>reactive</module>
 		<module>security</module>
@@ -32,7 +33,7 @@
 		<module>schema-validation</module>
 		<module>util</module>
 	</modules>
-	
+
 	<properties>
 		<embedded-mongo.version>2.1.1</embedded-mongo.version>
 	</properties>


### PR DESCRIPTION
# Spring Data Cassandra - Kotlin examples
 This project contains samples of Kotlin-specific features of Spring Data (Cassandra).
 ## Value defaulting on entity construction
 Kotlin allows defaulting for constructor- and method arguments. 
Defaulting allows usage of substitute values if a field in the document is absent or simply `null`. 
Spring Data inspects objects whether they are Kotlin types and uses the appropriate constructor.
 ```kotlin
@Table
data class Person(@PrimaryKeyColumn(type = PrimaryKeyType.PARTITIONED) val firstname: String? = "", val lastname: String = "White")
 operations.cqlOperations.execute(QueryBuilder.insertInto("person").value("firstname", "Walter"))
 val person = operations.query<Person>()
				.matching(query(where("firstname").isEqualTo("Walter")))
				.firstValue()!!
 assertThat(person.lastname).isEqualTo("White")
```
 ## Kotlin Extensions
 Spring Data exposes methods accepting a target type to either query for or to project results values on. 
Kotlin represents classes with its own type, `KClass` which can be an obstacle when attempting to obtain a Java `Class` type.
 Spring Data ships with extensions that add overloads for methods accepting a type parameter by either leveraging generics or accepting `KClass` directly.
 ```kotlin
operations.getTableName<Person>()
 
operations.getTableName(Person::class)
```
 ## Nullability
 Declaring repository interfaces using Kotlin allows expressing nullability constraints on arguments and return types. Spring Data evaluates nullability of arguments and return types and reacts to these. Passing `null` to a non-nullable argument raises an `IllegalArgumentException`, as you're already used to from Kotlin. Spring Data helps you also to prevent `null` in query results. If you wish to return a nullable result, use Kotlin's nullability marker `?`. To prevent `null` results, declare the return type of a query method as non-nullable. In the case a query yields no result, a non-nullable query method throws `EmptyResultDataAccessException`.  
 ```kotlin
interface PersonRepository : CrudRepository<Person, String> {
 	/**
	 * Query method declaring a nullable return type that allows to return null values.
	 */
	fun findOneOrNoneByFirstname(firstname: String): Person?
 	/**
	 * Query method declaring a nullable argument.
	 */
	fun findNullableByFirstname(firstname: String?): Person?
 	/**
	 * Query method requiring a result. Throws [org.springframework.dao.EmptyResultDataAccessException] if no result is found.
	 */
	fun findOneByFirstname(firstname: String): Person
}
```