### PR TITLE
#521 - Update Kotlin examples for MongoDB. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We have separate folders for the samples of individual modules:
 * `geo-json` - Example project showing usage of [GeoJSON](http://geojson.org) with MongoDB.
 * `gridfs` - Example project showing usage of gridFS with MongoDB.
 * `java8` - Example of how to use Spring Data MongoDB with Java 8 date time types as well as the usage of `Optional` as return type for repository methods. Note, this project requires to be build with JDK 8.
-* `kotlin` - Example for using Cassandra with MongoDB.
+* `kotlin` - Example for using [Kotlin](https://kotlinlang.org/) with MongoDB.
 * `query-by-example` - Example project showing usage of Query by Example with MongoDB.
 * `reactive` - Example project to show reactive template and repository support.
 * `security` - Example project showing usage of Spring Security with MongoDB.

--- a/mongodb/kotlin/README.md
+++ b/mongodb/kotlin/README.md
@@ -54,3 +54,12 @@ interface PersonRepository : CrudRepository<Person, String> {
 	fun findOneByFirstname(firstname: String): Person
 }
 ```
+
+## Type-Safe Kotlin Mongo Query DSL
+
+Using the `Criteria` extensions allows to write type-safe queries via an ideomatic API.
+
+```kotlin
+operations.find<Person>(Query(Person::firstname isEqualTo "Tyrion"))
+```
+

--- a/mongodb/kotlin/README.md
+++ b/mongodb/kotlin/README.md
@@ -63,3 +63,16 @@ Using the `Criteria` extensions allows to write type-safe queries via an ideomat
 operations.find<Person>(Query(Person::firstname isEqualTo "Tyrion"))
 ```
 
+## Coroutines and Flow support
+
+```kotlin
+runBlocking {
+	operations.find<Person>(Query(where("firstname").isEqualTo("Tyrion"))).awaitSingle()
+}
+```
+
+```kotlin
+runBlocking {
+	operations.findAll<Person>().asFlow().toList()
+}
+```

--- a/mongodb/kotlin/pom.xml
+++ b/mongodb/kotlin/pom.xml
@@ -11,7 +11,15 @@
 	<artifactId>spring-data-mongodb-kotlin</artifactId>
 	<name>Spring Data MongoDB - Kotlin features</name>
 
+    <properties>
+        <kotlin-coroutines>1.3.0-RC2</kotlin-coroutines>
+    </properties>
+
 	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb-reactive</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-stdlib-jdk8</artifactId>
@@ -19,6 +27,21 @@
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-reflect</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>${kotlin-coroutines}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-reactor</artifactId>
+            <version>${kotlin-coroutines}</version>
+        </dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/FlowAndCoroutinesTests.kt
+++ b/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/FlowAndCoroutinesTests.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.reactive.awaitSingle
+import kotlinx.coroutines.reactive.flow.asFlow
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.mongodb.core.*
+import org.springframework.data.mongodb.core.query.Criteria.where
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.isEqualTo
+import org.springframework.test.context.junit4.SpringRunner
+import reactor.test.StepVerifier
+
+/**
+ *
+ * @author Christoph Strobl
+ */
+@RunWith(SpringRunner::class)
+@SpringBootTest
+class FlowAndCoroutinesTests {
+
+	@Autowired
+	lateinit var operations: ReactiveMongoOperations
+
+	@Before
+	fun before() {
+		StepVerifier.create(operations.dropCollection<Person>()).verifyComplete()
+	}
+
+	@Test
+	fun `find - the coroutine way`() {
+
+		StepVerifier.create(operations.insert<Person>().one(Person("Tyrion", "Lannister"))).expectNextCount(1).verifyComplete()
+
+		assertThat(
+				runBlocking {
+					operations.find<Person>(Query(where("firstname").isEqualTo("Tyrion"))).awaitSingle()
+				}
+		).extracting("firstname").isEqualTo("Tyrion")
+	}
+
+	@Test
+	fun `find - the flow way`() {
+
+		StepVerifier.create(operations.insert<Person>().one(Person("Tyrion", "Lannister"))).expectNextCount(1).verifyComplete()
+		StepVerifier.create(operations.insert<Person>().one(Person("Cersei", "Lannister"))).expectNextCount(1).verifyComplete()
+
+		assertThat(
+				runBlocking {
+					operations.findAll<Person>().asFlow().toList()
+				}
+		).extracting("firstname").containsExactlyInAnyOrder("Tyrion", "Cersei")
+	}
+}

--- a/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/MongoDslTests.kt
+++ b/mongodb/kotlin/src/test/kotlin/example/springdata/mongodb/people/MongoDslTests.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.people;
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.mongodb.core.MongoOperations
+import org.springframework.data.mongodb.core.dropCollection
+import org.springframework.data.mongodb.core.find
+import org.springframework.data.mongodb.core.insert
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.isEqualTo
+import org.springframework.data.mongodb.core.query.regex
+import org.springframework.test.context.junit4.SpringRunner
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(SpringRunner::class)
+@SpringBootTest
+class MongoDslTests {
+
+	@Autowired
+	lateinit var operations: MongoOperations
+
+	@Before
+	fun before() {
+		operations.dropCollection<Person>()
+	}
+
+	@Test
+	fun `simple type-safe find`() {
+
+		operations.insert<Person>().one(Person("Tyrion", "Lannister"))
+		operations.insert<Person>().one(Person("Cersei", "Lannister"))
+
+		val people = operations.find<Person>(Query(Person::firstname isEqualTo "Tyrion"))
+		assertThat(people).hasSize(1).extracting("firstname").containsOnly("Tyrion")
+	}
+
+	@Test
+	fun `more complex type-safe find`() {
+
+		operations.insert<Person>().one(Person("Tyrion", "Lannister"))
+		operations.insert<Person>().one(Person("Cersei", "Lannister"))
+
+		val people = operations.find<Person>(Query( //
+				Criteria().andOperator(Person::lastname isEqualTo "Lannister", Person::firstname regex "^Cer.*") //
+		))
+		assertThat(people).hasSize(1).extracting("firstname").containsOnly("Cersei")
+	}
+}


### PR DESCRIPTION
- Add example for type-safe Kotlin MongoDB query DSL. 
- Add example for Kotlin Coroutines and Flow support with MongoDB.

closes: #521 