### PR TITLE
Change postgresql to h2

### DIFF
--- a/r2dbc/example/README.adoc
+++ b/r2dbc/example/README.adoc
@@ -4,7 +4,8 @@ This projects shows some sample usage of the work-in-progress R2DBC support for 
 
 === Interesting bits to look at
 
-- `InfrastructureConfiguration` - sets up a R2DBC `ConnectionFactory` based on the R2DBC Postgres driver (https://github.com/r2dbc/r2dbc-postgresql[r2dbc-postgresql]), a `DatabaseClient` and a `R2dbcRepositoryFactory` to eventually create a `CustomerRepository`.
+- `InfrastructureConfiguration` - sets up a R2DBC `ConnectionFactory` based on the R2DBC H2 driver (https://github.com/r2dbc/r2dbc-h2[r2dbc-h2]), a `DatabaseClient` and a `R2dbcRepositoryFactory` to eventually create a `CustomerRepository`.
 - `CustomerRepository` - a standard Spring Data reactive CRUD repository exposing query methods using manually defined queries
 - `CustomerRepositoryIntegrationTests` - to initialize the database with some setup SQL and the inserting and reading `Customer` instances.
 - `TransactionalService` - uses declarative transaction to apply a transactional boundary to repository operations.
+


### PR DESCRIPTION
Update README to mention the currently used database configuration h2 instead of postgresql. The configuration change was made in: https://github.com/spring-projects/spring-data-examples/commit/aa9ad225064f5adf612f1f97f48a8188c8dffe8d#diff-4db6b5f26b828b64870e18f0cb152658