### PR TITLE
Upgrade to 0.1.0.BUILD-SNAPSHOT.

### DIFF
--- a/r2dbc/pom.xml
+++ b/r2dbc/pom.xml
@@ -21,7 +21,7 @@
 	</modules>
 
 	<properties>
-		<spring-boot-data-r2dbc.version>0.1.0.M2</spring-boot-data-r2dbc.version>
+		<spring-boot-data-r2dbc.version>0.1.0.BUILD-SNAPSHOT</spring-boot-data-r2dbc.version>
 		<r2dbc-h2.version>0.8.0.BUILD-SNAPSHOT</r2dbc-h2.version>
 	</properties>
 


### PR DESCRIPTION
The tests will fail when changing the default H2 driver to postgres with the following error:

>  expectation "expectNextCount(1)" failed (expected: count = 1; actual: counted = 0; signal: onComplete()).

This is caused by null returned from the publisher after consuming the rowsUpdated result from [the DROP and CREATE statements]( https://github.com/fjacobs/DropCreateTest/blob/master/example/src/test/java/example/springdata/r2dbc/basics/DropCreateRowsUpdatedTest.java) as can be seen in the link. The statements are successfully executed in the database.

This issue is fixed in 0.1.0.BUILD-SNAPSHOT.

This may be related to issue
https://github.com/spring-projects/spring-data-r2dbc/issues/241.

