### PR TITLE
#547 - Fixes javadoc typo.

### DIFF
--- a/jpa/example/src/main/java/example/springdata/jpa/simple/SimpleUserRepository.java
+++ b/jpa/example/src/main/java/example/springdata/jpa/simple/SimpleUserRepository.java
@@ -38,7 +38,7 @@ public interface SimpleUserRepository extends CrudRepository<User, Long> {
 	 * Find the user with the given username. This method will be translated into a query using the
 	 * {@link javax.persistence.NamedQuery} annotation at the {@link User} class.
 	 *
-	 * @param lastname
+	 * @param username
 	 * @return
 	 */
 	User findByTheUsersName(String username);


### PR DESCRIPTION
`@param` name (`lastname`) isn't consistent with the actual parameter name in the code (`username`).