### PR TITLE
Use Elasticsearch 8.7.0 container in tests.

### DIFF
--- a/elasticsearch/example/src/test/java/example/springdata/elasticsearch/conference/ElasticsearchOperationsTest.java
+++ b/elasticsearch/example/src/test/java/example/springdata/elasticsearch/conference/ElasticsearchOperationsTest.java
@@ -15,23 +15,23 @@
  */
 package example.springdata.elasticsearch.conference;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.Criteria;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-
+import org.springframework.util.Assert;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -44,24 +44,30 @@ import org.testcontainers.utility.DockerImageName;
  * @author Oliver Gierke
  * @author Christoph Strobl
  * @author Prakhar Gupta
+ * @author Peter-Josef Meisch
  */
-@SpringBootTest(classes = ApplicationConfiguration.class)
+@SpringBootTest(classes = { ApplicationConfiguration.class, ElasticsearchOperationsTest.TestConfiguration.class })
 @Testcontainers
 class ElasticsearchOperationsTest {
 
 	private static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
-
 	@Container //
 	private static ElasticsearchContainer container = new ElasticsearchContainer(
-			DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:7.17.2")) //
-					.withPassword("foobar") //
-					.withReuse(true);
+			DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.7.0")) //
+			.withPassword("foobar");
 
-	@DynamicPropertySource
-	static void setProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.elasticsearch.uris", () -> "http://" + container.getHttpHostAddress());
-		registry.add("spring.elasticsearch.username", () -> "elastic");
-		registry.add("spring.elasticsearch.password", () -> "foobar");
+	@Configuration
+	static class TestConfiguration extends ElasticsearchConfiguration {
+		@Override
+		public ClientConfiguration clientConfiguration() {
+
+			Assert.notNull(container, "TestContainer is not initialized!");
+
+			return ClientConfiguration.builder() //
+					.connectedTo(container.getHttpHostAddress()).usingSsl(container.createSslContextFromCa()) //
+					.withBasicAuth("elastic", "foobar") //
+					.build();
+		}
 	}
 
 	@Autowired ElasticsearchOperations operations;

--- a/elasticsearch/example/src/test/java/example/springdata/elasticsearch/conference/ElasticsearchOperationsTest.java
+++ b/elasticsearch/example/src/test/java/example/springdata/elasticsearch/conference/ElasticsearchOperationsTest.java
@@ -15,7 +15,7 @@
  */
 package example.springdata.elasticsearch.conference;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -54,7 +54,8 @@ class ElasticsearchOperationsTest {
 	@Container //
 	private static ElasticsearchContainer container = new ElasticsearchContainer(
 			DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.7.0")) //
-			.withPassword("foobar");
+			.withPassword("foobar") //
+			.withReuse(true);
 
 	@Configuration
 	static class TestConfiguration extends ElasticsearchConfiguration {

--- a/elasticsearch/reactive/src/test/java/example/springdata/elasticsearch/conference/ReactiveElasticsearchOperationsTest.java
+++ b/elasticsearch/reactive/src/test/java/example/springdata/elasticsearch/conference/ReactiveElasticsearchOperationsTest.java
@@ -15,8 +15,7 @@
  */
 package example.springdata.elasticsearch.conference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 import reactor.test.StepVerifier;
 
@@ -56,7 +55,8 @@ class ReactiveElasticsearchOperationsTest {
 	@Container //
 	private static ElasticsearchContainer container = new ElasticsearchContainer(
 			DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.7.0")) //
-			.withPassword("foobar");
+			.withPassword("foobar") //
+			.withReuse(true);
 
 	@Configuration
 	static class TestConfiguration extends ReactiveElasticsearchConfiguration {

--- a/elasticsearch/reactive/src/test/java/example/springdata/elasticsearch/conference/ReactiveElasticsearchRepositoryTest.java
+++ b/elasticsearch/reactive/src/test/java/example/springdata/elasticsearch/conference/ReactiveElasticsearchRepositoryTest.java
@@ -15,8 +15,7 @@
  */
 package example.springdata.elasticsearch.conference;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 import reactor.test.StepVerifier;
 
@@ -52,7 +51,8 @@ class ReactiveElasticsearchRepositoryTest {
 	@Container //
 	private static ElasticsearchContainer container = new ElasticsearchContainer(
 			DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.7.0")) //
-			.withPassword("foobar");
+			.withPassword("foobar") //
+			.withReuse(true);
 
 	@Configuration
 	static class TestConfiguration extends ReactiveElasticsearchConfiguration {

--- a/elasticsearch/reactive/src/test/java/example/springdata/elasticsearch/conference/ReactiveElasticsearchRepositoryTest.java
+++ b/elasticsearch/reactive/src/test/java/example/springdata/elasticsearch/conference/ReactiveElasticsearchRepositoryTest.java
@@ -15,7 +15,8 @@
  */
 package example.springdata.elasticsearch.conference;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import reactor.test.StepVerifier;
 
@@ -23,12 +24,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchConfiguration;
+import org.springframework.util.Assert;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -39,8 +40,10 @@ import org.testcontainers.utility.DockerImageName;
  *
  * @author Christoph Strobl
  * @author Prakhar Gupta
+ * @author Peter-Josef Meisch
  */
-@SpringBootTest(classes = ApplicationConfiguration.class)
+@SpringBootTest(
+		classes = { ApplicationConfiguration.class, ReactiveElasticsearchRepositoryTest.TestConfiguration.class })
 @Testcontainers
 class ReactiveElasticsearchRepositoryTest {
 
@@ -48,15 +51,21 @@ class ReactiveElasticsearchRepositoryTest {
 
 	@Container //
 	private static ElasticsearchContainer container = new ElasticsearchContainer(
-			DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:7.17.2")) //
-					.withPassword("foobar") //
-					.withReuse(true);
+			DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.7.0")) //
+			.withPassword("foobar");
 
-	@DynamicPropertySource
-	static void setProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.elasticsearch.uris", () -> "http://" + container.getHttpHostAddress());
-		registry.add("spring.elasticsearch.username", () -> "elastic");
-		registry.add("spring.elasticsearch.password", () -> "foobar");
+	@Configuration
+	static class TestConfiguration extends ReactiveElasticsearchConfiguration {
+		@Override
+		public ClientConfiguration clientConfiguration() {
+
+			Assert.notNull(container, "TestContainer is not initialized!");
+
+			return ClientConfiguration.builder() //
+					.connectedTo(container.getHttpHostAddress()).usingSsl(container.createSslContextFromCa()) //
+					.withBasicAuth("elastic", "foobar") //
+					.build();
+		}
 	}
 
 	@Autowired ConferenceRepository repository;


### PR DESCRIPTION
This updates the Elasticsearch version used in TestContainers to the current 8.7.0.

I had to change the configuration a little to be able to handle the self signed certificate that Elasticsearch uses since version 8 for their service.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/main/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/main/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Close #660