### PR TITLE
feat(#530): Add example for $geoIntersects query

### DIFF
--- a/mongodb/example/src/main/java/example/springdata/mongodb/customer/Store.java
+++ b/mongodb/example/src/main/java/example/springdata/mongodb/customer/Store.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.springdata.mongodb.customer;
+
+import lombok.Data;
+import org.springframework.data.mongodb.core.geo.GeoJsonPolygon;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.util.Assert;
+
+/**
+ * An entity to represent a Store with a service area.
+ *
+ * @author Rishabh Saraswat
+ */
+@Data
+@Document
+public class Store {
+
+	private String id;
+	private final String name;
+	@GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
+	private final GeoJsonPolygon serviceArea; // unlike Polygon, GeoJsonPolygon is closed boundary
+
+	/**
+	 * Creates a new {@link Store} with the given name and service area.
+	 *
+	 * @param name        must not be {@literal null} or empty.
+	 * @param serviceArea must not be {@literal null}.
+	 */
+	public Store(String name, GeoJsonPolygon serviceArea) {
+		Assert.hasText(name, "Name must not be empty");
+		Assert.notNull(serviceArea, "Service area must not be null");
+		this.name = name;
+		this.serviceArea = serviceArea;
+	}
+}

--- a/mongodb/example/src/main/java/example/springdata/mongodb/customer/StoreRepository.java
+++ b/mongodb/example/src/main/java/example/springdata/mongodb/customer/StoreRepository.java
@@ -1,0 +1,11 @@
+package example.springdata.mongodb.customer;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Repository interface for {@link Store} instances.
+ *
+ * @author Rishabh Saraswat
+ */
+interface StoreRepository extends CrudRepository<Store, String>{
+}

--- a/mongodb/example/src/test/java/example/springdata/mongodb/customer/CustomerRepositoryIntegrationTest.java
+++ b/mongodb/example/src/test/java/example/springdata/mongodb/customer/CustomerRepositoryIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,43 +15,47 @@
  */
 package example.springdata.mongodb.customer;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.data.Offset.offset;
-
 import example.springdata.mongodb.util.MongoContainers;
-
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Metrics;
 import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
+import org.springframework.data.mongodb.core.geo.GeoJsonPolygon;
 import org.springframework.data.mongodb.core.index.GeospatialIndex;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.querydsl.QSort;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 /**
  * Integration test for {@link CustomerRepository}.
  *
  * @author Oliver Gierke
+ * @author Rishabh Saraswat
  */
 @Testcontainers
 @DataMongoTest
 class CustomerRepositoryIntegrationTest {
 
 	@Container //
-	private static MongoDBContainer mongoDBContainer = MongoContainers.getDefaultContainer();
+	private static final MongoDBContainer mongoDBContainer = MongoContainers.getDefaultContainer();
 
 	@DynamicPropertySource
 	static void setProperties(DynamicPropertyRegistry registry) {
@@ -60,17 +64,23 @@ class CustomerRepositoryIntegrationTest {
 
 	@Autowired CustomerRepository repository;
 	@Autowired MongoOperations operations;
+	@Autowired StoreRepository storeRepository;
 
 	private Customer dave, oliver, carter;
+	private Store store;
 
 	@BeforeEach
 	void setUp() {
 
 		repository.deleteAll();
 
+		GeoJsonPolygon polygon = new GeoJsonPolygon(new Point(0.0, 0.0), new Point(0.0, 1.0), new Point(1.0, 1.0), new Point(1.0, 0.0), new Point(0.0, 0.0));
+
 		dave = repository.save(new Customer("Dave", "Matthews"));
 		oliver = repository.save(new Customer("Oliver August", "Matthews"));
 		carter = repository.save(new Customer("Carter", "Beauford"));
+
+		store = storeRepository.save(new Store("store-1", polygon));
 	}
 
 	/**
@@ -145,5 +155,29 @@ class CustomerRepositoryIntegrationTest {
 		var distanceToFirstStore = result.getContent().get(0).getDistance();
 		assertThat(distanceToFirstStore.getMetric()).isEqualTo(Metrics.KILOMETERS);
 		assertThat(distanceToFirstStore.getValue()).isCloseTo(0.862, offset(0.001));
+	}
+
+	/**
+	 * Test case to show the usage of the geospatial operator {@code $geoIntersects}.
+	 */
+	@Test
+	void supportsGeoIntersectsPointInside() {
+		operations.indexOps(Store.class).createIndex(new GeospatialIndex("serviceArea"));
+		GeoJsonPoint pointInside = new GeoJsonPoint(0.5, 0.5);
+		Query pointInsideQuery = Query.query(Criteria.where("serviceArea").intersects(pointInside));
+
+		List<Store> stores = operations.find(pointInsideQuery, Store.class);
+		assertThat(stores).hasSize(1);
+		assertThat(stores.get(0).getName()).isEqualTo("store-1");
+	}
+
+	@Test
+	void supportsGeoIntersectsPointOutside() {
+		operations.indexOps(Store.class).createIndex(new GeospatialIndex("serviceArea"));
+		GeoJsonPoint pointOutside = new GeoJsonPoint(0.5, 0.5);
+		Query pointOutsideQuery = Query.query(Criteria.where("serviceArea").intersects(pointOutside));
+
+		List<Store> stores = operations.find(pointOutsideQuery, Store.class);
+		assertThat(stores).isEmpty();
 	}
 }


### PR DESCRIPTION
Closes #530.

#### Summary
This PR adds an example demonstrating the `$geoIntersects` query with Spring Data MongoDB. The new code is placed in the `customer` package to centralize geospatial examples.

#### Implementation
*   **`Store` Entity:** A new entity with a `GeoJsonPolygon` field annotated with `@GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)`.
*   **Integration Test:** A new test in `CustomerRepositoryIntegrationTest` uses `MongoOperations` and `Criteria.where("serviceArea").intersects(point)` to show how to execute the query programmatically.
*   **Test Scenarios:** The test covers finding a `Store` where a point is both inside and outside the service area to ensure correctness.