### PR TITLE
refactor(Database): Replace deprecated ensureIndex with createIndex

### DIFF
--- a/mongodb/example/src/test/java/example/springdata/mongodb/customer/CustomerRepositoryIntegrationTest.java
+++ b/mongodb/example/src/test/java/example/springdata/mongodb/customer/CustomerRepositoryIntegrationTest.java
@@ -129,7 +129,7 @@ class CustomerRepositoryIntegrationTest {
 		indexDefinition.getIndexOptions().put("min", -180);
 		indexDefinition.getIndexOptions().put("max", 180);
 
-		operations.indexOps(Customer.class).ensureIndex(indexDefinition);
+		operations.indexOps(Customer.class).createIndex(indexDefinition);
 
 		var ollie = new Customer("Oliver", "Gierke");
 		ollie.setAddress(new Address(new Point(52.52548, 13.41477)));


### PR DESCRIPTION
### **Description**

This pull request addresses the use of the deprecated `ensureIndex()` method in the database initialization logic. The method is no longer recommended by the MongoDB driver and produces deprecation warnings in the logs.

To align with best practices and ensure future compatibility, this change replaces all instances of `ensureIndex()` with the modern equivalent, `createIndex()`. 

Closes #703